### PR TITLE
Fixing directory allowed/forbidden patterns usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/tauri-apps/tauri-plugin-persisted-scope"
 edition = "2021"
 
 [dependencies]
-tauri = "1.0"
+tauri = "1.2.2"
 thiserror = "1"
 serde = "1.0"
 serde_json = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             let is_recursive = allowed.ends_with("**");
 
             if is_folder {
-              let path = allowed.replace(if is_recursive {"\\**"} else {"\\*"}, "");
+              let path = allowed.replace(if is_recursive { "\\**" } else { "\\*" }, "");
               let _ = fs_scope.allow_directory(&path, is_recursive);
               #[cfg(feature = "protocol-asset")]
               let _ = asset_protocol_scope.allow_directory(path, is_recursive);
@@ -79,7 +79,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             let is_recursive = allowed.ends_with("**");
 
             if is_folder {
-              let path = allowed.replace(if is_recursive {"\\**"} else {"\\*"}, "");
+              let path = allowed.replace(if is_recursive { "\\**" } else { "\\*" }, "");
               let _ = fs_scope.allow_directory(&path, is_recursive);
               #[cfg(feature = "protocol-asset")]
               let _ = asset_protocol_scope.forbid_directory(path, is_recursive);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             let is_recursive = allowed.ends_with("**");
 
             if is_folder {
-              let path = allowed.replace("\\**", "");
+              let path = allowed.replace(if is_recursive {"\\**"} else {"\\*"}, "");
               let _ = fs_scope.allow_directory(&path, is_recursive);
               #[cfg(feature = "protocol-asset")]
               let _ = asset_protocol_scope.allow_directory(path, is_recursive);
@@ -79,7 +79,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             let is_recursive = allowed.ends_with("**");
 
             if is_folder {
-              let path = allowed.replace("\\**", "");
+              let path = allowed.replace(if is_recursive {"\\**"} else {"\\*"}, "");
               let _ = fs_scope.allow_directory(&path, is_recursive);
               #[cfg(feature = "protocol-asset")]
               let _ = asset_protocol_scope.forbid_directory(path, is_recursive);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,9 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
       let fs_scope = app.fs_scope();
       #[cfg(feature = "protocol-asset")]
       let asset_protocol_scope = app.asset_protocol_scope();
+
       let app = app.clone();
-      let app_dir = app.path_resolver().app_dir();
+      let app_dir = app.path_resolver().app_config_dir();
 
       if let Some(app_dir) = app_dir {
         let scope_state_path = app_dir.join(SCOPE_STATE_FILENAME);


### PR DESCRIPTION
I made a quick-fix for the issue tauri-apps/plugins-workspace#25
The error seems to be that we are using the patterns and not paths of files/directories.
Feel a bit quick & dirty to me, so I'll be happy to make changes and more.

Also updating the dependency to use Tauri 1.2.2

You can test it with this modified [example](https://github.com/OrIOg/vanilla-folder/tree/asset-protocol-folder-dev)
_Only tested on Windows 10 64bit_

Still, it is weird that the problem was mostly affecting the asset-protocol.